### PR TITLE
Windows gamepad_anykey Update

### DIFF
--- a/Monkeyv2/Monkey.yyp/Monkey.resource_order
+++ b/Monkeyv2/Monkey.yyp/Monkey.resource_order
@@ -10,6 +10,7 @@
     {"name":"oWall","order":3,"path":"objects/oWall/oWall.yy",},
     {"name":"rmInit","order":2,"path":"rooms/rmInit/rmInit.yy",},
     {"name":"Room1","order":3,"path":"rooms/Room1/Room1.yy",},
+    {"name":"monkeyConstants","order":6,"path":"scripts/monkeyConstants/monkeyConstants.yy",},
     {"name":"MonkeyFunctions","order":1,"path":"scripts/MonkeyFunctions/MonkeyFunctions.yy",},
     {"name":"monkeyInit","order":2,"path":"scripts/monkeyInit/monkeyInit.yy",},
     {"name":"both_L3","order":1,"path":"sprites/both_L3/both_L3.yy",},

--- a/Monkeyv2/Monkey.yyp/Monkey.yyp
+++ b/Monkeyv2/Monkey.yyp/Monkey.yyp
@@ -38,6 +38,7 @@
     {"id":{"name":"oWall","path":"objects/oWall/oWall.yy",},},
     {"id":{"name":"rmInit","path":"rooms/rmInit/rmInit.yy",},},
     {"id":{"name":"Room1","path":"rooms/Room1/Room1.yy",},},
+    {"id":{"name":"monkeyConstants","path":"scripts/monkeyConstants/monkeyConstants.yy",},},
     {"id":{"name":"MonkeyDependencies","path":"scripts/MonkeyDependencies/MonkeyDependencies.yy",},},
     {"id":{"name":"MonkeyFunctions","path":"scripts/MonkeyFunctions/MonkeyFunctions.yy",},},
     {"id":{"name":"monkeyInit","path":"scripts/monkeyInit/monkeyInit.yy",},},

--- a/Monkeyv2/Monkey.yyp/objects/oMonkeyGamepadBrain/Create_0.gml
+++ b/Monkeyv2/Monkey.yyp/objects/oMonkeyGamepadBrain/Create_0.gml
@@ -14,5 +14,8 @@ gp_slots[3] = -1
 
 // Disconnected DualSense/DualShock constant L1 press related code
 if os_type == os_windows {
-    l1Held = 0
+    l2Held[0] = 0
+    l2Held[1] = 0
+    l2Held[2] = 0
+    l2Held[3] = 0
 }

--- a/Monkeyv2/Monkey.yyp/objects/oMonkeyGamepadBrain/Create_0.gml
+++ b/Monkeyv2/Monkey.yyp/objects/oMonkeyGamepadBrain/Create_0.gml
@@ -11,3 +11,8 @@ gp_slots[0] = -1
 gp_slots[1] = -1
 gp_slots[2] = -1
 gp_slots[3] = -1
+
+// Disconnected DualSense/DualShock constant L1 press related code
+if os_type == os_windows {
+    l1Held = 0
+}

--- a/Monkeyv2/Monkey.yyp/objects/oMonkeyGamepadBrain/Other_75.gml
+++ b/Monkeyv2/Monkey.yyp/objects/oMonkeyGamepadBrain/Other_75.gml
@@ -10,16 +10,17 @@ switch(async_load[? "event_type"])
 		for(var i = 0; i < 4; i++) {
 			if gp_slots[i] == -1 {
 				gp_slots[i] = pad
-				//Uncomment this line for debug messages of the gamepads and the slots
-				show_debug_message("Registered pad " + gamepad_get_description(pad) + " on slot " + string(i))
+                _monkey_dependency_log("Registered pad " + gamepad_get_description(i) + " on slot " + string(i))
 				global.gamepad_connected = true
 				
 				//Checks gamepads descriptions in search for xbox controllers 
 				//Checking the slots (0-3 || 4-11) is inconsistent in MacOS
 				if (string_pos("Xbox", gamepad_get_description(pad)) || string_pos("xbox", gamepad_get_description(pad)) || string_pos("XBOX", gamepad_get_description(pad))) {
 					global.gamepad_is_xbox[i] = true
+                    _monkey_dependency_log("Gamepad slot " + string(i) + " (" + gamepad_get_description(i) + ")" + " set as Xbox Gamepad")
 				} else {
 					global.gamepad_is_xbox[i] = false
+                    _monkey_dependency_log("Gamepad slot " + string(i) + " (" + gamepad_get_description(i) + ")" + " set as Non-Xbox Gamepad")
 				}
 				_monkey_dependency_update_gp_last(i)
 				break
@@ -33,7 +34,7 @@ switch(async_load[? "event_type"])
 				gp_slots[i] = -1
 				_monkey_dependency_update_gp_last(0)
 				global.gamepad_connected = false
-                show_debug_message("Lost pad " + gamepad_get_description(pad) + " on slot " + string(i))
+                _monkey_dependency_log("Lost pad " + gamepad_get_description(pad) + " on slot " + string(i))
 				break
 			}
 		}

--- a/Monkeyv2/Monkey.yyp/objects/oMonkeyGamepadBrain/Other_75.gml
+++ b/Monkeyv2/Monkey.yyp/objects/oMonkeyGamepadBrain/Other_75.gml
@@ -21,7 +21,7 @@ switch(async_load[? "event_type"])
 				} else {
 					global.gamepad_is_xbox[i] = false
 				}
-				monkeyUpdateGpLast(i)
+				_monkey_dependency_update_gp_last(i)
 				break
 			}
 		}
@@ -31,7 +31,7 @@ switch(async_load[? "event_type"])
 		for(var i = 0; i < 4; i++) {
 			if gp_slots[i] == pad {
 				gp_slots[i] = -1
-				monkeyUpdateGpLast(0)
+				_monkey_dependency_update_gp_last(0)
 				global.gamepad_connected = false
                 show_debug_message("Lost pad " + gamepad_get_description(pad) + " on slot " + string(i))
 				break

--- a/Monkeyv2/Monkey.yyp/objects/oMonkeyGamepadBrain/Step_0.gml
+++ b/Monkeyv2/Monkey.yyp/objects/oMonkeyGamepadBrain/Step_0.gml
@@ -7,11 +7,11 @@ if global.gamepad_connected {
 
 // Set the last used controller
 for(var i = 0; i < 4; i++) {
-    if _monkey_dependency_gamepad_anykey(gp_slots[i]) {
+    var keyPressed = _monkey_dependency_gamepad_anykey(i)
+    if keyPressed {
         global.gamepad_connected = true
     }
 
-    var keyPressed = _monkey_dependency_gamepad_anykey(gp_slots[i])
     global.gamepad_is_connected = true
     if keyPressed {
         if gp_last != i {

--- a/Monkeyv2/Monkey.yyp/objects/oMonkeyGamepadBrain/Step_0.gml
+++ b/Monkeyv2/Monkey.yyp/objects/oMonkeyGamepadBrain/Step_0.gml
@@ -7,15 +7,15 @@ if global.gamepad_connected {
 
 // Set the last used controller
 for(var i = 0; i < 4; i++) {
-    if gamepad_anykey(gp_slots[i]) {
+    if _monkey_dependency_gamepad_anykey(gp_slots[i]) {
         global.gamepad_connected = true
     }
 
-    var keyPressed = gamepad_anykey(gp_slots[i])
+    var keyPressed = _monkey_dependency_gamepad_anykey(gp_slots[i])
     global.gamepad_is_connected = true
     if keyPressed {
         if gp_last != i {
-            monkeyUpdateGpLast(i)
+            _monkey_dependency_update_gp_last(i)
         }
     }
 }

--- a/Monkeyv2/Monkey.yyp/objects/oMonkeyMouse/Step_0.gml
+++ b/Monkeyv2/Monkey.yyp/objects/oMonkeyMouse/Step_0.gml
@@ -1,1 +1,1 @@
-status = monkeyGetInputMouse(mb_input)
+status = monkeyGetInputMouse(mb_input, heldFrames)

--- a/Monkeyv2/Monkey.yyp/scripts/MonkeyDependencies/monkeydependencies.gml
+++ b/Monkeyv2/Monkey.yyp/scripts/MonkeyDependencies/monkeydependencies.gml
@@ -1,30 +1,48 @@
-function _monkey_dependency_gamepad_anykey(slot) {
+function _monkey_dependency_gamepad_anykey(gpSlot) {
+    if gpSlot < 0 || gpSlot > 3  { exit }
+    var slot = gp_slots[gpSlot]
     for(var i = gp_face1; i <= gp_padr; i++) {
         if i == gp_shoulderlb {
-            if os_type == os_windows {
+            if _monkey_dependency_ds_l1_check(gpSlot) { 
+                _monkey_dependency_log("Controller slot " + string(gpSlot) + " anykey call has been ignored due to a DualShock/DualSense glitch with Windows")
                 return false
             }
         }
         if (gamepad_button_check(slot, i)) return i;
     }
     for(var i = gp_axislh; i <= gp_axisrv; i++) {
-        if abs(gamepad_axis_value(slot, i )) return i;
+        if abs(gamepad_axis_value(slot, i)) return i;
     }
 }
 
-function _monkey_dependency_ds_l1_check(button, slot) {
+// Returns TRUE if the input should be ignored
+function _monkey_dependency_ds_l1_check(gpSlot) {
     // Windows disconnected DualShock/DualSense L1 glitch
-    if os_type == os_windows {
-        if button == gp_shoulderlb {
-            l1Held += 1
-        }
-        return l1Held < MONKEY_L1HELDWINDOWSTHRESHOLD
+    var slot = gp_slots[gpSlot]
+    if os_type != os_windows {
+        return false
     }
+    if global.gamepad_is_xbox[gpSlot] {
+        return false
+    }
+    if gamepad_button_check(slot, gp_shoulderlb) {
+        oMonkeyGamepadBrain.l2Held[gpSlot] += 1
+        var value = oMonkeyGamepadBrain.l2Held[gpSlot] > MONKEY_l2HeldWINDOWSTHRESHOLD
+        return value
+    } else {
+        oMonkeyGamepadBrain.l2Held[gpSlot] = 0
+        return false
+    }
+}
+
+function _monkey_dependency_log(log) {
+    // TODO: if logs active
+    show_debug_message("[MONKEY] " + string(log))
 }
 
 function _monkey_dependency_update_gp_last(newValue) {
     gp_last = newValue
-    show_debug_message("Last used gamepad (gp_last) set to slot " + string(newValue))
+    _monkey_dependency_log("Last used gamepad (gp_last) set to slot " + string(newValue))
 }
 
 function monkeyGetInputKeyboard(vk_input, heldFrames) {

--- a/Monkeyv2/Monkey.yyp/scripts/MonkeyDependencies/monkeydependencies.gml
+++ b/Monkeyv2/Monkey.yyp/scripts/MonkeyDependencies/monkeydependencies.gml
@@ -100,14 +100,14 @@ function monkeyGetInputGamepad(gp_input, gp_slot, heldFrames) {
 function monkeyGetInputMouse(mb_input, heldFrames){
 	if mouse_check_button(mb_input) {
 		var status = MONKEY.OFF;
-		if (held < heldFrames) {
-			status = MONKEY.PRESSED
-			held++
-			return status
-		} else  {
-			status = MONKEY.HELD
-			return status;
-		}
+        if (held < heldFrames) {
+            status = MONKEY.PRESSED
+            held++
+            return status
+        } else {
+            status = MONKEY.HELD
+            return status;
+        }
 	} else {
 		if (held > 0.9) {
 			held = 0;

--- a/Monkeyv2/Monkey.yyp/scripts/MonkeyDependencies/monkeydependencies.gml
+++ b/Monkeyv2/Monkey.yyp/scripts/MonkeyDependencies/monkeydependencies.gml
@@ -12,6 +12,16 @@ function _monkey_dependency_gamepad_anykey(slot) {
     }
 }
 
+function _monkey_dependency_ds_l1_check(button, slot) {
+    // Windows disconnected DualShock/DualSense L1 glitch
+    if os_type == os_windows {
+        if button == gp_shoulderlb {
+            l1Held += 1
+        }
+        return l1Held < MONKEY_L1HELDWINDOWSTHRESHOLD
+    }
+}
+
 function _monkey_dependency_update_gp_last(newValue) {
     gp_last = newValue
     show_debug_message("Last used gamepad (gp_last) set to slot " + string(newValue))

--- a/Monkeyv2/Monkey.yyp/scripts/MonkeyDependencies/monkeydependencies.gml
+++ b/Monkeyv2/Monkey.yyp/scripts/MonkeyDependencies/monkeydependencies.gml
@@ -1,18 +1,18 @@
-function gamepad_anykey(slot) {
+function _monkey_dependency_gamepad_anykey(slot) {
     for(var i = gp_face1; i <= gp_padr; i++) {
-        if i == gp_shoulderlb{
+        if i == gp_shoulderlb {
             if os_type == os_windows {
                 return false
             }
         }
         if (gamepad_button_check(slot, i)) return i;
     }
-    for(var i = gp_axislh;i <= gp_axisrv; i++) {
+    for(var i = gp_axislh; i <= gp_axisrv; i++) {
         if abs(gamepad_axis_value(slot, i )) return i;
     }
 }
 
-function monkeyUpdateGpLast(newValue) {
+function _monkey_dependency_update_gp_last(newValue) {
     gp_last = newValue
     show_debug_message("Last used gamepad (gp_last) set to slot " + string(newValue))
 }

--- a/Monkeyv2/Monkey.yyp/scripts/MonkeyFunctions/monkeyfunctions.gml
+++ b/Monkeyv2/Monkey.yyp/scripts/MonkeyFunctions/monkeyfunctions.gml
@@ -68,10 +68,14 @@ function monkeyDeleteVirtualKey(ID){
 }
 
 function monkeyRemapKey(ID, newKeyboardKey, newGamepadKey){
-	monkeyList[ID].vkHolder = virtual_key_add(monkeyList[ID].xPos, monkeyList[ID].yPos, monkeyList[ID].vkWidth, monkeyList[ID].vkHeight, newKeyboardKey);
+    if monkeyList[ID].vkEnabled {
+       monkeyList[ID].vkHolder = virtual_key_add(monkeyList[ID].xPos, monkeyList[ID].yPos, monkeyList[ID].vkWidth, monkeyList[ID].vkHeight, newKeyboardKey); 
+    }
 	monkeyList[ID].inputType = newKeyboardKey;
 	monkeyList[ID].gamepadInput = newGamepadKey;
-	monkeyList[ID].monkeyUpdateSprites();
+    with (monkeyList[ID]) {
+       monkeyUpdateSprites()
+    }
 }
 
 function monkeyGetKeyboardBinding(ID){
@@ -106,6 +110,7 @@ function monkeyUpdateSprites(){
 			case vk_divide: break;
 			case vk_down: vkSprite = key_arrowdown; break;
 			case vk_end: break;
+            case vk_escape: vkSprite = key_esc; break;
 			case vk_enter: vkSprite = key_enter; break;
 			case vk_f1: vkSprite = key_F1; break;
 			case vk_f2: vkSprite = key_F2; break;
@@ -287,7 +292,7 @@ function monkeyUpdateSprites(){
 				}
 				else
 				{
-					gpSprite = ds4_l2;	
+					gpSprite = ds4_r2;	
 				}break;
 			case gp_start: 
 				if global.gamepad_is_xbox[gp_slot]

--- a/Monkeyv2/Monkey.yyp/scripts/monkeyConstants/monkeyConstants.gml
+++ b/Monkeyv2/Monkey.yyp/scripts/monkeyConstants/monkeyConstants.gml
@@ -1,3 +1,3 @@
 // The amount of frames L1 has to be pressed for it to not register as "any key" in Windows.
 // This is used to go around an issue where disconnected DualShock/DualSense devices will report to press L1 after being turned off
-#macro MONKEY_L1HELDWINDOWSTHRESHOLD 30
+#macro MONKEY_l2HeldWINDOWSTHRESHOLD 60

--- a/Monkeyv2/Monkey.yyp/scripts/monkeyConstants/monkeyConstants.gml
+++ b/Monkeyv2/Monkey.yyp/scripts/monkeyConstants/monkeyConstants.gml
@@ -1,0 +1,3 @@
+// The amount of frames L1 has to be pressed for it to not register as "any key" in Windows.
+// This is used to go around an issue where disconnected DualShock/DualSense devices will report to press L1 after being turned off
+#macro MONKEY_L1HELDWINDOWSTHRESHOLD 30

--- a/Monkeyv2/Monkey.yyp/scripts/monkeyConstants/monkeyConstants.yy
+++ b/Monkeyv2/Monkey.yyp/scripts/monkeyConstants/monkeyConstants.yy
@@ -1,0 +1,13 @@
+{
+  "$GMScript":"v1",
+  "%Name":"monkeyConstants",
+  "isCompatibility":false,
+  "isDnD":false,
+  "name":"monkeyConstants",
+  "parent":{
+    "name":"MONKEY",
+    "path":"folders/MONKEY.yy",
+  },
+  "resourceType":"GMScript",
+  "resourceVersion":"2.0",
+}


### PR DESCRIPTION
- Updates gamepad_anykey to ignore DualShock/DualSense devices after a second of pressing L2 [only on Windows]
- Fixes a crash related to missing vkSprite for ESC
- Fixes a crash related to mouse listeners not being persistent
- Includes new log function (WIP)
- Fixes a bug where mouse listeners would not report their held state